### PR TITLE
Fixed the problem when Chrome audio permission is not "Allow"

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,42 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <title>Guess My Number!</title>
   </head>
   <body>
+    <!-- backdrop needed for allowing audio -->
+    <div id="backdrop">Click me to start the game</div>
     <header>
       <h1>Guess The Number</h1>
       <p class="between">(Between 1 and 20)</p>

--- a/script.js
+++ b/script.js
@@ -11,8 +11,33 @@
 // });
 
 window.onload = function () {
-  let audio = new Audio("./assets/start.mp3");
-  audio.play();
+  const audio = new Audio("./assets/start.mp3");
+  audio.muted = true;
+
+  function playAudio() {
+    audio.pause();
+    audio.currentTime = 0;
+    audio.muted = false;
+    audio.play();
+  }
+
+  // try to play audio to see if it works, on Chrome without
+  // audio permission this would not work as interaction from
+  // the use is needed first.
+  audio.play().then(() => {
+    // audio is allowed, no problems, just unmute and restart
+    playAudio();
+  }).catch(() => {
+    // we need to show a modal here and ask the user to click
+    // it to start the game.
+    document.querySelector("#backdrop").classList.add("revealed");
+    document.querySelector("#backdrop").addEventListener(
+      'click', _ => {
+        document.querySelector("#backdrop").classList.remove("revealed");
+        playAudio();
+      }
+    )
+  });
 };
 
 let secretNumber = Math.trunc(Math.random() * 20) + 1;

--- a/style.css
+++ b/style.css
@@ -118,3 +118,24 @@ h1 {
 .label-score {
   margin-bottom: 2rem;
 }
+
+/* added by Orwa for audio-starting backdrop */
+#backdrop {
+  position: fixed;
+  z-index: 100;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background:rgba(0, 0, 0, 0.8);
+  display: none;
+  font-size: 3rem;
+  font-weight: bold;
+  color: white;
+}
+
+#backdrop.revealed {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
In this update (two commits) I am introducing a backdrop screen on startup that requires the user to click.

Once clicked, the interaction with the page started and it is possible to play audio without problems.